### PR TITLE
replace salvador with alex

### DIFF
--- a/exercise/cities_lived_in.rb
+++ b/exercise/cities_lived_in.rb
@@ -17,9 +17,9 @@ cities_lived_in = {
 # Write code that iterates through the `cities_lived_in` hash, and returns a list of  
 # names of the humans who've lived in Philadelphia.
 
-# [:michaela, :mike, :salvador]
+# [:michaela, :mike, :alex]
 # or
-# ["Michaela", "Mike", "Salvador"]
+# ["Michaela", "Mike", "Alex"]
 
 
 


### PR DESCRIPTION
Updated the `cities_lived_in.rb` file to replace **Salvador** with **Alex** in Problem #2. **Salvador** does not appear in the `cities_lived_in` hash defined on line 1.